### PR TITLE
Made buffers unlisted

### DIFF
--- a/plugin/gundo.vim
+++ b/plugin/gundo.vim
@@ -158,7 +158,7 @@ function! s:GundoMarkPreviewBuffer()
     setlocal buftype=nofile
     setlocal bufhidden=hide
     setlocal noswapfile
-    setlocal buflisted
+    setlocal nobuflisted
     setlocal nomodifiable
     setlocal filetype=diff
     setlocal nonumber
@@ -172,7 +172,7 @@ function! s:GundoMarkBuffer()
     setlocal buftype=nofile
     setlocal bufhidden=hide
     setlocal noswapfile
-    setlocal buflisted
+    setlocal nobuflisted
     setlocal nomodifiable
     setlocal filetype=gundo
     setlocal nolist


### PR DESCRIPTION
Hey Steve,

This is a pretty cool project :) Also, I really liked your "coming home to vim" post.

My change makes both buffers unlisted. I didn't like them to be in my BufExplorer list, and I thought that, in general, it would be preferable to not have them be listed. If you agree, great! If not, I'd be interested in what use case you see for listed Gundo buffers. I'd also be willing to add a Gundo option to specify whether they are listed; let me know what you think.

-Caleb Spare
