### PR TITLE
Add g:gundo_preview_bottom option

### DIFF
--- a/doc/gundo.txt
+++ b/doc/gundo.txt
@@ -19,7 +19,8 @@ CONTENTS                                                      *Gundo-contents*
     3. Configuration .................. |GundoConfig|
         3.1 gundo_width ............... |gundo_width|
         3.2 gundo_preview_height ...... |gundo_preview_height|
-        3.2 gundo_right ............... |gundo_right|
+        3.3 gundo_preview_bottom ...... |gundo_preview_bottom|
+        3.4 gundo_right ............... |gundo_right|
     4. License ........................ |GundoLicense|
     5. Bugs ........................... |GundoBugs|
     6. Contributing ................... |GundoContributing|
@@ -136,7 +137,24 @@ Set the vertical height of the Gundo preview.
 Default: 15
 
 ------------------------------------------------------------------------------
-3.3 g:gundo_right                                                *gundo_right*
+3.3 g:gundo_preview_bottom                              *gundo_preview_bottom*
+
+Force the preview window below current windows instead of below the graph.
+This gives the preview window more space to show the unified diff.
+
+Example:
+
+   +--------+            +--------+
+   !g!      !            !      !g!
+   !g!      !     or     !      !g!
+   !g!______!            !______!g!
+   !g!pppppp!            !pppppp!g!
+   +--------+            +--------+
+
+Default: 0
+
+------------------------------------------------------------------------------
+3.4 g:gundo_right                                                *gundo_right*
 
 Set this to 1 to make the Gundo graph (and preview) open on the right side
 instead of the left.

--- a/plugin/gundo.vim
+++ b/plugin/gundo.vim
@@ -48,6 +48,9 @@ endif"}}}
 if !exists('g:gundo_preview_height')"{{{
     let g:gundo_preview_height = 15
 endif"}}}
+if !exists('g:gundo_preview_bottom')"{{{
+    let g:gundo_preview_bottom = 0
+endif"}}}
 if !exists('g:gundo_right')"{{{
     let g:gundo_right = 0
 endif"}}}
@@ -542,6 +545,13 @@ function! s:GundoOpenGraph()"{{{
     if existing_gundo_buffer == -1
         exe bufwinnr(bufnr('__Gundo_Preview__')) . "wincmd w"
         exe "new __Gundo__"
+        if g:gundo_preview_bottom
+            if g:gundo_right
+                wincmd L
+            else
+                wincmd H
+            endif
+        endif
         call s:GundoResizeBuffers(winnr())
     else
         let existing_gundo_window = bufwinnr(existing_gundo_buffer)
@@ -552,7 +562,15 @@ function! s:GundoOpenGraph()"{{{
             endif
         else
             exe bufwinnr(bufnr('__Gundo_Preview__')) . "wincmd w"
-            exe "split +buffer" . existing_gundo_buffer
+            if g:gundo_preview_bottom
+                if g:gundo_right
+                    exe "botright vsplit +buffer" . existing_gundo_buffer
+                else
+                    exe "topleft vsplit +buffer" . existing_gundo_buffer
+                endif
+            else
+                exe "split +buffer" . existing_gundo_buffer
+            endif
             call s:GundoResizeBuffers(winnr())
         endif
     endif
@@ -562,12 +580,14 @@ function! s:GundoOpenPreview()"{{{
     let existing_preview_buffer = bufnr("__Gundo_Preview__")
 
     if existing_preview_buffer == -1
-        exe "vnew __Gundo_Preview__"
-
-        if g:gundo_right
-            wincmd L
+        if g:gundo_preview_bottom
+            exe "botright new __Gundo_Preview__"
         else
-            wincmd H
+            if g:gundo_right
+                exe "botright vnew __Gundo_Preview__"
+            else
+                exe "topleft vnew __Gundo_Preview__"
+            endif
         endif
     else
         let existing_preview_window = bufwinnr(existing_preview_buffer)
@@ -577,12 +597,14 @@ function! s:GundoOpenPreview()"{{{
                 exe existing_preview_window . "wincmd w"
             endif
         else
-            exe "vsplit +buffer" . existing_preview_buffer
-
-            if g:gundo_right
-                wincmd L
+            if g:gundo_preview_bottom
+                exe "botright split +buffer" . existing_preview_buffer
             else
-                wincmd H
+                if g:gundo_right
+                    exe "botright vsplit +buffer" . existing_preview_buffer
+                else
+                    exe "topleft vsplit +buffer" . existing_preview_buffer
+                endif
             endif
         endif
     endif


### PR DESCRIPTION
The following adds a `g:gundo_preview_bottom` option to allow the preview window to expand the entire width of the window (minus the undo graph).  Documentation updates are included.

I tried to find a shorter way to doing it as this patch adds quite a few lines but I was unable to find a better way.

On a side note, you have some variables defined globally (`g:gundo_target_n` and `g:gundo_target_f`) that I'm not sure should/need to be.  Should those just be script local instead?
