### PR TITLE
Added support for Python 3

### DIFF
--- a/plugin/gundo.py
+++ b/plugin/gundo.py
@@ -1,0 +1,565 @@
+# vim:fileencoding=utf-8
+
+#{{{ imports
+import sys, vim, time
+import itertools
+import difflib
+if sys.version_info[0] == 3:
+    from io import StringIO
+else:
+    class StringIO(object):
+        def __init__(self):
+            self.b = ''
+        def write(self, s):
+            self.b += s
+        def getvalue(self):
+            return self.b
+#}}}
+
+#{{{ Mercurial's graphlog code
+def asciiedges(seen, rev, parents):
+    """adds edge info to changelog DAG walk suitable for ascii()"""
+    if rev not in seen:
+        seen.append(rev)
+    nodeidx = seen.index(rev)
+
+    knownparents = []
+    newparents = []
+    for parent in parents:
+        if parent in seen:
+            knownparents.append(parent)
+        else:
+            newparents.append(parent)
+
+    ncols = len(seen)
+    seen[nodeidx:nodeidx + 1] = newparents
+    edges = [(nodeidx, seen.index(p)) for p in knownparents]
+
+    if len(newparents) > 0:
+        edges.append((nodeidx, nodeidx))
+    if len(newparents) > 1:
+        edges.append((nodeidx, nodeidx + 1))
+
+    nmorecols = len(seen) - ncols
+    return nodeidx, edges, ncols, nmorecols
+
+def get_nodeline_edges_tail(
+        node_index, p_node_index, n_columns, n_columns_diff, p_diff, fix_tail):
+    if fix_tail and n_columns_diff == p_diff and n_columns_diff != 0:
+        # Still going in the same non-vertical direction.
+        if n_columns_diff == -1:
+            start = max(node_index + 1, p_node_index)
+            tail = ["|", " "] * (start - node_index - 1)
+            tail.extend(["/", " "] * (n_columns - start))
+            return tail
+        else:
+            return ["\\", " "] * (n_columns - node_index - 1)
+    else:
+        return ["|", " "] * (n_columns - node_index - 1)
+
+def draw_edges(edges, nodeline, interline):
+    for (start, end) in edges:
+        if start == end + 1:
+            interline[2 * end + 1] = "/"
+        elif start == end - 1:
+            interline[2 * start + 1] = "\\"
+        elif start == end:
+            interline[2 * start] = "|"
+        else:
+            nodeline[2 * end] = "+"
+            if start > end:
+                (start, end) = (end, start)
+            for i in range(2 * start + 1, 2 * end):
+                if nodeline[i] != "+":
+                    nodeline[i] = "-"
+
+def fix_long_right_edges(edges):
+    for (i, (start, end)) in enumerate(edges):
+        if end > start:
+            edges[i] = (start, end + 1)
+
+def ascii(buf, state, type, char, text, coldata):
+    """prints an ASCII graph of the DAG
+
+    takes the following arguments (one call per node in the graph):
+
+      - Somewhere to keep the needed state in (init to asciistate())
+      - Column of the current node in the set of ongoing edges.
+      - Type indicator of node data == ASCIIDATA.
+      - Payload: (char, lines):
+        - Character to use as node's symbol.
+        - List of lines to display as the node's text.
+      - Edges; a list of (col, next_col) indicating the edges between
+        the current node and its parents.
+      - Number of columns (ongoing edges) in the current revision.
+      - The difference between the number of columns (ongoing edges)
+        in the next revision and the number of columns (ongoing edges)
+        in the current revision. That is: -1 means one column removed;
+        0 means no columns added or removed; 1 means one column added.
+    """
+
+    idx, edges, ncols, coldiff = coldata
+    assert -2 < coldiff < 2
+    if coldiff == -1:
+        # Transform
+        #
+        #     | | |        | | |
+        #     o | |  into  o---+
+        #     |X /         |/ /
+        #     | |          | |
+        fix_long_right_edges(edges)
+
+    # add_padding_line says whether to rewrite
+    #
+    #     | | | |        | | | |
+    #     | o---+  into  | o---+
+    #     |  / /         |   | |  # <--- padding line
+    #     o | |          |  / /
+    #                    o | |
+    add_padding_line = (len(text) > 2 and coldiff == -1 and
+                        [x for (x, y) in edges if x + 1 < y])
+
+    # fix_nodeline_tail says whether to rewrite
+    #
+    #     | | o | |        | | o | |
+    #     | | |/ /         | | |/ /
+    #     | o | |    into  | o / /   # <--- fixed nodeline tail
+    #     | |/ /           | |/ /
+    #     o | |            o | |
+    fix_nodeline_tail = len(text) <= 2 and not add_padding_line
+
+    # nodeline is the line containing the node character (typically o)
+    nodeline = ["|", " "] * idx
+    nodeline.extend([char, " "])
+
+    nodeline.extend(
+        get_nodeline_edges_tail(idx, state[1], ncols, coldiff,
+                                state[0], fix_nodeline_tail))
+
+    # shift_interline is the line containing the non-vertical
+    # edges between this entry and the next
+    shift_interline = ["|", " "] * idx
+    if coldiff == -1:
+        n_spaces = 1
+        edge_ch = "/"
+    elif coldiff == 0:
+        n_spaces = 2
+        edge_ch = "|"
+    else:
+        n_spaces = 3
+        edge_ch = "\\"
+    shift_interline.extend(n_spaces * [" "])
+    shift_interline.extend([edge_ch, " "] * (ncols - idx - 1))
+
+    # draw edges from the current node to its parents
+    draw_edges(edges, nodeline, shift_interline)
+
+    # lines is the list of all graph lines to print
+    lines = [nodeline]
+    if add_padding_line:
+        lines.append(get_padding_line(idx, ncols, edges))
+    lines.append(shift_interline)
+
+    # make sure that there are as many graph lines as there are
+    # log strings
+    while len(text) < len(lines):
+        text.append("")
+    if len(lines) < len(text):
+        extra_interline = ["|", " "] * (ncols + coldiff)
+        while len(lines) < len(text):
+            lines.append(extra_interline)
+
+    # print lines
+    indentation_level = max(ncols, ncols + coldiff)
+    for (line, logstr) in zip(lines, text):
+        ln = "%-*s %s" % (2 * indentation_level, "".join(line), logstr)
+        buf.write(ln.rstrip() + '\n')
+
+    # ... and start over
+    state[0] = coldiff
+    state[1] = idx
+
+def generate(dag, edgefn, current):
+    seen, state = [], [0, 0]
+    buf = StringIO()
+    for node, parents in dag:
+        if node.time:
+            age_label = age(int(node.time))
+        else:
+            age_label = 'Original'
+        line = '[%s] %s' % (node.n, age_label)
+        if node.n == current:
+            char = '@'
+        else:
+            char = 'o'
+        ascii(buf, state, 'C', char, [line], edgefn(seen, node, parents))
+    return buf.getvalue()
+#}}}
+
+#{{{ Mercurial age function
+agescales = [("year", 3600 * 24 * 365),
+             ("month", 3600 * 24 * 30),
+             ("week", 3600 * 24 * 7),
+             ("day", 3600 * 24),
+             ("hour", 3600),
+             ("minute", 60),
+             ("second", 1)]
+
+def age(ts):
+    '''turn a timestamp into an age string.'''
+
+    def plural(t, c):
+        if c == 1:
+            return t
+        return t + "s"
+    def fmt(t, c):
+        return "%d %s" % (c, plural(t, c))
+
+    now = time.time()
+    then = ts
+    if then > now:
+        return 'in the future'
+
+    delta = max(1, int(now - then))
+    if delta > agescales[0][1] * 2:
+        return time.strftime('%Y-%m-%d', time.gmtime(float(ts)))
+
+    for t, s in agescales:
+        n = delta // s
+        if n >= 2 or s == 1:
+            return '%s ago' % fmt(t, n)
+#}}}
+
+#{{{ Python Vim utility functions
+normal = lambda s: vim.command('normal %s' % s)
+
+MISSING_BUFFER = "Cannot find Gundo's target buffer (%s)"
+MISSING_WINDOW = "Cannot find window (%s) for Gundo's target buffer (%s)"
+
+def _check_sanity():
+    '''Check to make sure we're not crazy.
+
+    Does the following things:
+
+        * Make sure the target buffer still exists.
+    '''
+    b = int(vim.eval('g:gundo_target_n'))
+
+    if not vim.eval('bufloaded(%d)' % b):
+        vim.command('echo "%s"' % (MISSING_BUFFER % b))
+        return False
+
+    w = int(vim.eval('bufwinnr(%d)' % b))
+    if w == -1:
+        vim.command('echo "%s"' % (MISSING_WINDOW % (w, b)))
+        return False
+
+    return True
+
+def _goto_window_for_buffer(b):
+    w = int(vim.eval('bufwinnr(%d)' % int(b)))
+    vim.command('%dwincmd w' % w)
+
+def _goto_window_for_buffer_name(bn):
+    b = vim.eval('bufnr("%s")' % bn)
+    return _goto_window_for_buffer(b)
+
+def _undo_to(n):
+    n = int(n)
+    if n == 0:
+        vim.command('silent earlier %s' % (int(vim.eval('&undolevels')) + 1))
+    else:
+        vim.command('silent undo %d' % n)
+
+
+INLINE_HELP = '''\
+" Gundo for %s (%d)
+" j/k  - move between undo states
+" p    - preview diff of selected and current states
+" <cr> - revert to selected state
+
+'''
+#}}}
+
+#{{{ Python undo tree data structures and functions
+class Node(object):
+    def __init__(self, n, parent, time, curhead):
+        self.n = int(n)
+        self.parent = parent
+        self.children = []
+        self.curhead = curhead
+        self.time = time
+
+def _make_nodes(alts, nodes, parent=None):
+    p = parent
+
+    for alt in alts:
+        curhead = 'curhead' in alt
+        node = Node(n=alt['seq'], parent=p, time=alt['time'], curhead=curhead)
+        nodes.append(node)
+        if alt.get('alt'):
+            _make_nodes(alt['alt'], nodes, p)
+        p = node
+
+def make_nodes():
+    ut = vim.eval('undotree()')
+    entries = ut['entries']
+
+    root = Node(0, None, False, 0)
+    nodes = []
+    _make_nodes(entries, nodes, root)
+    nodes.append(root)
+    nmap = dict((node.n, node) for node in nodes)
+    return nodes, nmap
+
+def changenr(nodes):
+    _curhead_l = list(itertools.dropwhile(lambda n: not n.curhead, nodes))
+    if _curhead_l:
+        current = _curhead_l[0].parent.n
+    else:
+        current = int(vim.eval('changenr()'))
+    return current
+#}}}
+
+#{{{ Rendering utility functions
+def _fmt_time(t):
+    return time.strftime('%Y-%m-%d %I:%M:%S %p', time.localtime(float(t)))
+
+def _output_preview_text(lines):
+    _goto_window_for_buffer_name('__Gundo_Preview__')
+    vim.command('setlocal modifiable')
+    vim.current.buffer[:] = lines
+    vim.command('setlocal nomodifiable')
+
+def _generate_preview_diff(current, node_before, node_after):
+    _goto_window_for_buffer(vim.eval('g:gundo_target_n'))
+
+    if not node_after.n:    # we're at the original file
+        before_lines = []
+
+        _undo_to(0)
+        after_lines = vim.current.buffer[:]
+
+        before_name = 'n/a'
+        before_time = ''
+        after_name = 'Original'
+        after_time = ''
+    elif not node_before.n: # we're at a pseudo-root state
+        _undo_to(0)
+        before_lines = vim.current.buffer[:]
+
+        _undo_to(node_after.n)
+        after_lines = vim.current.buffer[:]
+
+        before_name = 'Original'
+        before_time = ''
+        after_name = node_after.n
+        after_time = _fmt_time(node_after.time)
+    else:
+        _undo_to(node_before.n)
+        before_lines = vim.current.buffer[:]
+
+        _undo_to(node_after.n)
+        after_lines = vim.current.buffer[:]
+
+        before_name = node_before.n
+        before_time = _fmt_time(node_before.time)
+        after_name = node_after.n
+        after_time = _fmt_time(node_after.time)
+
+    _undo_to(current)
+
+    return list(difflib.unified_diff(before_lines, after_lines,
+                                     before_name, after_name,
+                                     before_time, after_time))
+
+def _generate_change_preview_diff(current, node_before, node_after):
+    _goto_window_for_buffer(vim.eval('g:gundo_target_n'))
+
+    _undo_to(node_before.n)
+    before_lines = vim.current.buffer[:]
+
+    _undo_to(node_after.n)
+    after_lines = vim.current.buffer[:]
+
+    before_name = node_before.n or 'Original'
+    before_time = node_before.time and _fmt_time(node_before.time) or ''
+    after_name = node_after.n or 'Original'
+    after_time = node_after.time and _fmt_time(node_after.time) or ''
+
+    _undo_to(current)
+
+    return list(difflib.unified_diff(before_lines, after_lines,
+                                     before_name, after_name,
+                                     before_time, after_time))
+#}}}
+
+def GundoRenderGraph():#{{{
+    if not _check_sanity():
+        return
+
+    nodes, nmap = make_nodes()
+
+    for node in nodes:
+        node.children = [n for n in nodes if n.parent == node]
+
+    def walk_nodes(nodes):
+        for node in nodes:
+            if node.parent:
+                yield (node, [node.parent])
+            else:
+                yield (node, [])
+
+    dag = sorted(nodes, key=lambda n: int(n.n), reverse=True)
+    current = changenr(nodes)
+
+    result = generate(walk_nodes(dag), asciiedges, current).rstrip().splitlines()
+    result = [' ' + l for l in result]
+
+    target = (vim.eval('g:gundo_target_f'), int(vim.eval('g:gundo_target_n')))
+
+    if int(vim.eval('g:gundo_help')):
+        header = (INLINE_HELP % target).splitlines()
+    else:
+        header = []
+
+    vim.command('call s:GundoOpenGraph()')
+    vim.command('setlocal modifiable')
+    vim.current.buffer[:] = (header + result)
+    vim.command('setlocal nomodifiable')
+
+    i = 1
+    for line in result:
+        try:
+            line.split('[')[0].index('@')
+            i += 1
+            break
+        except ValueError:
+            pass
+        i += 1
+    vim.command('%d' % (i+len(header)-1))
+#}}}
+
+def GundoRenderPreview():#{{{
+    if not _check_sanity():
+        return
+
+    target_state = vim.eval('s:GundoGetTargetState()')
+
+    # Check that there's an undo state. There may not be if we're talking about
+    # a buffer with no changes yet.
+    if target_state == None:
+        _goto_window_for_buffer_name('__Gundo__')
+        return
+    else:
+        target_state = int(target_state)
+
+    _goto_window_for_buffer(vim.eval('g:gundo_target_n'))
+
+    nodes, nmap = make_nodes()
+    current = changenr(nodes)
+
+    node_after = nmap[target_state]
+    node_before = node_after.parent
+
+    vim.command('call s:GundoOpenPreview()')
+    _output_preview_text(_generate_preview_diff(current, node_before, node_after))
+
+    _goto_window_for_buffer_name('__Gundo__')
+#}}}
+
+def GundoRenderChangePreview():#{{{
+    if not _check_sanity():
+        return
+
+    target_state = vim.eval('s:GundoGetTargetState()')
+
+    # Check that there's an undo state. There may not be if we're talking about
+    # a buffer with no changes yet.
+    if target_state == None:
+        _goto_window_for_buffer_name('__Gundo__')
+        return
+    else:
+        target_state = int(target_state)
+
+    _goto_window_for_buffer(vim.eval('g:gundo_target_n'))
+
+    nodes, nmap = make_nodes()
+    current = changenr(nodes)
+
+    node_after = nmap[target_state]
+    node_before = nmap[current]
+
+    vim.command('call s:GundoOpenPreview()')
+    _output_preview_text(_generate_change_preview_diff(current, node_before, node_after))
+
+    _goto_window_for_buffer_name('__Gundo__')
+#}}}
+
+def GundoRevert():#{{{
+    if not _check_sanity():
+        return
+
+    target_n = int(vim.eval('s:GundoGetTargetState()'))
+    back = vim.eval('g:gundo_target_n')
+
+    _goto_window_for_buffer(back)
+    _undo_to(target_n)
+
+    vim.command('GundoRenderGraph')
+    _goto_window_for_buffer(back)
+#}}}
+
+def GundoPlayTo():#{{{
+    if not _check_sanity():
+        return
+
+    target_n = int(vim.eval('s:GundoGetTargetState()'))
+    back = int(vim.eval('g:gundo_target_n'))
+
+    vim.command('echo "%s"' % back)
+
+    _goto_window_for_buffer(back)
+    normal('zR')
+
+    nodes, nmap = make_nodes()
+
+    start = nmap[changenr(nodes)]
+    end = nmap[target_n]
+
+    def _walk_branch(origin, dest):
+        rev = origin.n < dest.n
+
+        nodes = []
+        if origin.n > dest.n:
+            current, final = origin, dest
+        else:
+            current, final = dest, origin
+
+        while current.n >= final.n:
+            if current.n == final.n:
+                break
+            nodes.append(current)
+            current = current.parent
+        else:
+            return None
+        nodes.append(current)
+
+        return reversed(nodes) if rev else nodes
+
+    branch = _walk_branch(start, end)
+
+    if not branch:
+        vim.command('unsilent echo "No path to that node from here!"')
+        return
+
+    for node in branch:
+        _undo_to(node.n)
+        vim.command('GundoRenderGraph')
+        normal('zz')
+        _goto_window_for_buffer(back)
+        vim.command('redraw')
+        vim.command('sleep 60m')
+#}}}
+
+# vim:se fdm=marker:sw=4:

--- a/plugin/gundo.vim
+++ b/plugin/gundo.vim
@@ -24,7 +24,9 @@ if v:version < '703'"{{{
     finish
 endif"}}}
 
-if has('python')"{{{
+if has('python3')"{{{
+    let s:has_supported_python = 2
+elseif has('python')
     let s:has_supported_python = 1
 
 python << ENDPYTHON
@@ -69,330 +71,21 @@ endif"}}}
 
 "}}}
 
-"{{{ Mercurial's graphlog code
-python << ENDPYTHON
-def asciiedges(seen, rev, parents):
-    """adds edge info to changelog DAG walk suitable for ascii()"""
-    if rev not in seen:
-        seen.append(rev)
-    nodeidx = seen.index(rev)
+"{{{ Execute python codes
+let pyfile = fnameescape(globpath(&runtimepath, 'plugin/gundo.py'))
+if s:has_supported_python == 2
+  exe 'py3file ' . pyfile
+else
+  exe 'pyfile ' . pyfile
+endif
 
-    knownparents = []
-    newparents = []
-    for parent in parents:
-        if parent in seen:
-            knownparents.append(parent)
-        else:
-            newparents.append(parent)
-
-    ncols = len(seen)
-    seen[nodeidx:nodeidx + 1] = newparents
-    edges = [(nodeidx, seen.index(p)) for p in knownparents]
-
-    if len(newparents) > 0:
-        edges.append((nodeidx, nodeidx))
-    if len(newparents) > 1:
-        edges.append((nodeidx, nodeidx + 1))
-
-    nmorecols = len(seen) - ncols
-    return nodeidx, edges, ncols, nmorecols
-
-def get_nodeline_edges_tail(
-        node_index, p_node_index, n_columns, n_columns_diff, p_diff, fix_tail):
-    if fix_tail and n_columns_diff == p_diff and n_columns_diff != 0:
-        # Still going in the same non-vertical direction.
-        if n_columns_diff == -1:
-            start = max(node_index + 1, p_node_index)
-            tail = ["|", " "] * (start - node_index - 1)
-            tail.extend(["/", " "] * (n_columns - start))
-            return tail
-        else:
-            return ["\\", " "] * (n_columns - node_index - 1)
-    else:
-        return ["|", " "] * (n_columns - node_index - 1)
-
-def draw_edges(edges, nodeline, interline):
-    for (start, end) in edges:
-        if start == end + 1:
-            interline[2 * end + 1] = "/"
-        elif start == end - 1:
-            interline[2 * start + 1] = "\\"
-        elif start == end:
-            interline[2 * start] = "|"
-        else:
-            nodeline[2 * end] = "+"
-            if start > end:
-                (start, end) = (end, start)
-            for i in range(2 * start + 1, 2 * end):
-                if nodeline[i] != "+":
-                    nodeline[i] = "-"
-
-def fix_long_right_edges(edges):
-    for (i, (start, end)) in enumerate(edges):
-        if end > start:
-            edges[i] = (start, end + 1)
-
-def ascii(buf, state, type, char, text, coldata):
-    """prints an ASCII graph of the DAG
-
-    takes the following arguments (one call per node in the graph):
-
-      - Somewhere to keep the needed state in (init to asciistate())
-      - Column of the current node in the set of ongoing edges.
-      - Type indicator of node data == ASCIIDATA.
-      - Payload: (char, lines):
-        - Character to use as node's symbol.
-        - List of lines to display as the node's text.
-      - Edges; a list of (col, next_col) indicating the edges between
-        the current node and its parents.
-      - Number of columns (ongoing edges) in the current revision.
-      - The difference between the number of columns (ongoing edges)
-        in the next revision and the number of columns (ongoing edges)
-        in the current revision. That is: -1 means one column removed;
-        0 means no columns added or removed; 1 means one column added.
-    """
-
-    idx, edges, ncols, coldiff = coldata
-    assert -2 < coldiff < 2
-    if coldiff == -1:
-        # Transform
-        #
-        #     | | |        | | |
-        #     o | |  into  o---+
-        #     |X /         |/ /
-        #     | |          | |
-        fix_long_right_edges(edges)
-
-    # add_padding_line says whether to rewrite
-    #
-    #     | | | |        | | | |
-    #     | o---+  into  | o---+
-    #     |  / /         |   | |  # <--- padding line
-    #     o | |          |  / /
-    #                    o | |
-    add_padding_line = (len(text) > 2 and coldiff == -1 and
-                        [x for (x, y) in edges if x + 1 < y])
-
-    # fix_nodeline_tail says whether to rewrite
-    #
-    #     | | o | |        | | o | |
-    #     | | |/ /         | | |/ /
-    #     | o | |    into  | o / /   # <--- fixed nodeline tail
-    #     | |/ /           | |/ /
-    #     o | |            o | |
-    fix_nodeline_tail = len(text) <= 2 and not add_padding_line
-
-    # nodeline is the line containing the node character (typically o)
-    nodeline = ["|", " "] * idx
-    nodeline.extend([char, " "])
-
-    nodeline.extend(
-        get_nodeline_edges_tail(idx, state[1], ncols, coldiff,
-                                state[0], fix_nodeline_tail))
-
-    # shift_interline is the line containing the non-vertical
-    # edges between this entry and the next
-    shift_interline = ["|", " "] * idx
-    if coldiff == -1:
-        n_spaces = 1
-        edge_ch = "/"
-    elif coldiff == 0:
-        n_spaces = 2
-        edge_ch = "|"
-    else:
-        n_spaces = 3
-        edge_ch = "\\"
-    shift_interline.extend(n_spaces * [" "])
-    shift_interline.extend([edge_ch, " "] * (ncols - idx - 1))
-
-    # draw edges from the current node to its parents
-    draw_edges(edges, nodeline, shift_interline)
-
-    # lines is the list of all graph lines to print
-    lines = [nodeline]
-    if add_padding_line:
-        lines.append(get_padding_line(idx, ncols, edges))
-    lines.append(shift_interline)
-
-    # make sure that there are as many graph lines as there are
-    # log strings
-    while len(text) < len(lines):
-        text.append("")
-    if len(lines) < len(text):
-        extra_interline = ["|", " "] * (ncols + coldiff)
-        while len(lines) < len(text):
-            lines.append(extra_interline)
-
-    # print lines
-    indentation_level = max(ncols, ncols + coldiff)
-    for (line, logstr) in zip(lines, text):
-        ln = "%-*s %s" % (2 * indentation_level, "".join(line), logstr)
-        buf.write(ln.rstrip() + '\n')
-
-    # ... and start over
-    state[0] = coldiff
-    state[1] = idx
-
-def generate(dag, edgefn, current):
-    seen, state = [], [0, 0]
-    buf = Buffer()
-    for node, parents in list(dag):
-        if node.time:
-            age_label = age(int(node.time))
-        else:
-            age_label = 'Original'
-        line = '[%s] %s' % (node.n, age_label)
-        if node.n == current:
-            char = '@'
-        else:
-            char = 'o'
-        ascii(buf, state, 'C', char, [line], edgefn(seen, node, parents))
-    return buf.b
-ENDPYTHON
-"}}}
-
-"{{{ Mercurial age function
-python << ENDPYTHON
-import time
-
-agescales = [("year", 3600 * 24 * 365),
-             ("month", 3600 * 24 * 30),
-             ("week", 3600 * 24 * 7),
-             ("day", 3600 * 24),
-             ("hour", 3600),
-             ("minute", 60),
-             ("second", 1)]
-
-def age(ts):
-    '''turn a timestamp into an age string.'''
-
-    def plural(t, c):
-        if c == 1:
-            return t
-        return t + "s"
-    def fmt(t, c):
-        return "%d %s" % (c, plural(t, c))
-
-    now = time.time()
-    then = ts
-    if then > now:
-        return 'in the future'
-
-    delta = max(1, int(now - then))
-    if delta > agescales[0][1] * 2:
-        return time.strftime('%Y-%m-%d', time.gmtime(float(ts)))
-
-    for t, s in agescales:
-        n = delta // s
-        if n >= 2 or s == 1:
-            return '%s ago' % fmt(t, n)
-ENDPYTHON
-"}}}
-
-"{{{ Python Vim utility functions
-python << ENDPYTHON
-import vim
-
-normal = lambda s: vim.command('normal %s' % s)
-
-MISSING_BUFFER = "Cannot find Gundo's target buffer (%s)"
-MISSING_WINDOW = "Cannot find window (%s) for Gundo's target buffer (%s)"
-
-def _check_sanity():
-    '''Check to make sure we're not crazy.
-
-    Does the following things:
-
-        * Make sure the target buffer still exists.
-    '''
-    b = int(vim.eval('g:gundo_target_n'))
-
-    if not vim.eval('bufloaded(%d)' % b):
-        vim.command('echo "%s"' % (MISSING_BUFFER % b))
-        return False
-
-    w = int(vim.eval('bufwinnr(%d)' % b))
-    if w == -1:
-        vim.command('echo "%s"' % (MISSING_WINDOW % (w, b)))
-        return False
-
-    return True
-
-def _goto_window_for_buffer(b):
-    w = int(vim.eval('bufwinnr(%d)' % int(b)))
-    vim.command('%dwincmd w' % w)
-
-def _goto_window_for_buffer_name(bn):
-    b = vim.eval('bufnr("%s")' % bn)
-    return _goto_window_for_buffer(b)
-
-def _undo_to(n):
-    n = int(n)
-    if n == 0:
-        vim.command('silent earlier %s' % (int(vim.eval('&undolevels')) + 1))
-    else:
-        vim.command('silent undo %d' % n)
-
-
-INLINE_HELP = '''\
-" Gundo for %s (%d)
-" j/k  - move between undo states
-" p    - preview diff of selected and current states
-" <cr> - revert to selected state
-
-'''
-ENDPYTHON
-"}}}
-
-"{{{ Python undo tree data structures and functions
-python << ENDPYTHON
-import itertools
-
-class Buffer(object):
-    def __init__(self):
-        self.b = ''
-
-    def write(self, s):
-        self.b += s
-
-class Node(object):
-    def __init__(self, n, parent, time, curhead):
-        self.n = int(n)
-        self.parent = parent
-        self.children = []
-        self.curhead = curhead
-        self.time = time
-
-def _make_nodes(alts, nodes, parent=None):
-    p = parent
-
-    for alt in alts:
-        curhead = 'curhead' in alt
-        node = Node(n=alt['seq'], parent=p, time=alt['time'], curhead=curhead)
-        nodes.append(node)
-        if alt.get('alt'):
-            _make_nodes(alt['alt'], nodes, p)
-        p = node
-
-def make_nodes():
-    ut = vim.eval('undotree()')
-    entries = ut['entries']
-
-    root = Node(0, None, False, 0)
-    nodes = []
-    _make_nodes(entries, nodes, root)
-    nodes.append(root)
-    nmap = dict((node.n, node) for node in nodes)
-    return nodes, nmap
-
-def changenr(nodes):
-    _curhead_l = list(itertools.dropwhile(lambda n: not n.curhead, nodes))
-    if _curhead_l:
-        current = _curhead_l[0].parent.n
-    else:
-        current = int(vim.eval('changenr()'))
-    return current
-ENDPYTHON
+function! s:python(code)
+  if s:has_supported_python == 2
+    exe 'py3 ' . a:code
+  else
+    exe 'py ' . a:code
+  endif
+endfunction
 "}}}
 
 "{{{ Gundo utility functions
@@ -671,198 +364,16 @@ endfunction"}}}
 
 "{{{ Gundo rendering
 
-"{{{ Rendering utility functions
-python << ENDPYTHON
-import difflib
-
-def _fmt_time(t):
-    return time.strftime('%Y-%m-%d %I:%M:%S %p', time.localtime(float(t)))
-
-def _output_preview_text(lines):
-    _goto_window_for_buffer_name('__Gundo_Preview__')
-    vim.command('setlocal modifiable')
-    vim.current.buffer[:] = lines
-    vim.command('setlocal nomodifiable')
-
-def _generate_preview_diff(current, node_before, node_after):
-    _goto_window_for_buffer(vim.eval('g:gundo_target_n'))
-
-    if not node_after.n:    # we're at the original file
-        before_lines = []
-
-        _undo_to(0)
-        after_lines = vim.current.buffer[:]
-
-        before_name = 'n/a'
-        before_time = ''
-        after_name = 'Original'
-        after_time = ''
-    elif not node_before.n: # we're at a pseudo-root state
-        _undo_to(0)
-        before_lines = vim.current.buffer[:]
-
-        _undo_to(node_after.n)
-        after_lines = vim.current.buffer[:]
-
-        before_name = 'Original'
-        before_time = ''
-        after_name = node_after.n
-        after_time = _fmt_time(node_after.time)
-    else:
-        _undo_to(node_before.n)
-        before_lines = vim.current.buffer[:]
-
-        _undo_to(node_after.n)
-        after_lines = vim.current.buffer[:]
-
-        before_name = node_before.n
-        before_time = _fmt_time(node_before.time)
-        after_name = node_after.n
-        after_time = _fmt_time(node_after.time)
-
-    _undo_to(current)
-
-    return list(difflib.unified_diff(before_lines, after_lines,
-                                     before_name, after_name,
-                                     before_time, after_time))
-
-def _generate_change_preview_diff(current, node_before, node_after):
-    _goto_window_for_buffer(vim.eval('g:gundo_target_n'))
-
-    _undo_to(node_before.n)
-    before_lines = vim.current.buffer[:]
-
-    _undo_to(node_after.n)
-    after_lines = vim.current.buffer[:]
-
-    before_name = node_before.n or 'Original'
-    before_time = node_before.time and _fmt_time(node_before.time) or ''
-    after_name = node_after.n or 'Original'
-    after_time = node_after.time and _fmt_time(node_after.time) or ''
-
-    _undo_to(current)
-
-    return list(difflib.unified_diff(before_lines, after_lines,
-                                     before_name, after_name,
-                                     before_time, after_time))
-ENDPYTHON
-"}}}
-
 function! s:GundoRenderGraph()"{{{
-python << ENDPYTHON
-def GundoRenderGraph():
-    if not _check_sanity():
-        return
-
-    nodes, nmap = make_nodes()
-
-    for node in nodes:
-        node.children = [n for n in nodes if n.parent == node]
-
-    def walk_nodes(nodes):
-        for node in nodes:
-            if node.parent:
-                yield (node, [node.parent])
-            else:
-                yield (node, [])
-
-    dag = sorted(nodes, key=lambda n: int(n.n), reverse=True)
-    current = changenr(nodes)
-
-    result = generate(walk_nodes(dag), asciiedges, current).rstrip().splitlines()
-    result = [' ' + l for l in result]
-
-    target = (vim.eval('g:gundo_target_f'), int(vim.eval('g:gundo_target_n')))
-
-    if int(vim.eval('g:gundo_help')):
-        header = (INLINE_HELP % target).splitlines()
-    else:
-        header = []
-
-    vim.command('call s:GundoOpenGraph()')
-    vim.command('setlocal modifiable')
-    vim.current.buffer[:] = (header + result)
-    vim.command('setlocal nomodifiable')
-
-    i = 1
-    for line in result:
-        try:
-            line.split('[')[0].index('@')
-            i += 1
-            break
-        except ValueError:
-            pass
-        i += 1
-    vim.command('%d' % (i+len(header)-1))
-
-GundoRenderGraph()
-ENDPYTHON
+    call s:python("GundoRenderGraph()")
 endfunction"}}}
 
 function! s:GundoRenderPreview()"{{{
-python << ENDPYTHON
-def GundoRenderPreview():
-    if not _check_sanity():
-        return
-
-    target_state = vim.eval('s:GundoGetTargetState()')
-
-    # Check that there's an undo state. There may not be if we're talking about
-    # a buffer with no changes yet.
-    if target_state == None:
-        _goto_window_for_buffer_name('__Gundo__')
-        return
-    else:
-        target_state = int(target_state)
-
-    _goto_window_for_buffer(vim.eval('g:gundo_target_n'))
-
-    nodes, nmap = make_nodes()
-    current = changenr(nodes)
-
-    node_after = nmap[target_state]
-    node_before = node_after.parent
-
-    vim.command('call s:GundoOpenPreview()')
-    _output_preview_text(_generate_preview_diff(current, node_before, node_after))
-
-    _goto_window_for_buffer_name('__Gundo__')
-
-GundoRenderPreview()
-ENDPYTHON
+    call s:python("GundoRenderPreview()")
 endfunction"}}}
 
 function! s:GundoRenderChangePreview()"{{{
-python << ENDPYTHON
-def GundoRenderChangePreview():
-    if not _check_sanity():
-        return
-
-    target_state = vim.eval('s:GundoGetTargetState()')
-
-    # Check that there's an undo state. There may not be if we're talking about
-    # a buffer with no changes yet.
-    if target_state == None:
-        _goto_window_for_buffer_name('__Gundo__')
-        return
-    else:
-        target_state = int(target_state)
-
-    _goto_window_for_buffer(vim.eval('g:gundo_target_n'))
-
-    nodes, nmap = make_nodes()
-    current = changenr(nodes)
-
-    node_after = nmap[target_state]
-    node_before = nmap[current]
-
-    vim.command('call s:GundoOpenPreview()')
-    _output_preview_text(_generate_change_preview_diff(current, node_before, node_after))
-
-    _goto_window_for_buffer_name('__Gundo__')
-
-GundoRenderChangePreview()
-ENDPYTHON
+    call s:python("GundoRenderChangePreview()")
 endfunction"}}}
 
 "}}}
@@ -870,79 +381,11 @@ endfunction"}}}
 "{{{ Gundo undo/redo
 
 function! s:GundoRevert()"{{{
-python << ENDPYTHON
-def GundoRevert():
-    if not _check_sanity():
-        return
-
-    target_n = int(vim.eval('s:GundoGetTargetState()'))
-    back = vim.eval('g:gundo_target_n')
-
-    _goto_window_for_buffer(back)
-    _undo_to(target_n)
-
-    vim.command('GundoRenderGraph')
-    _goto_window_for_buffer(back)
-
-GundoRevert()
-ENDPYTHON
+    call s:python("GundoRevert()")
 endfunction"}}}
 
 function! s:GundoPlayTo()"{{{
-python << ENDPYTHON
-def GundoPlayTo():
-    if not _check_sanity():
-        return
-
-    target_n = int(vim.eval('s:GundoGetTargetState()'))
-    back = int(vim.eval('g:gundo_target_n'))
-
-    vim.command('echo "%s"' % back)
-
-    _goto_window_for_buffer(back)
-    normal('zR')
-
-    nodes, nmap = make_nodes()
-
-    start = nmap[changenr(nodes)]
-    end = nmap[target_n]
-
-    def _walk_branch(origin, dest):
-        rev = origin.n < dest.n
-
-        nodes = []
-        if origin.n > dest.n:
-            current, final = origin, dest
-        else:
-            current, final = dest, origin
-
-        while current.n >= final.n:
-            if current.n == final.n:
-                break
-            nodes.append(current)
-            current = current.parent
-        else:
-            return None
-        nodes.append(current)
-
-        return reversed(nodes) if rev else nodes
-
-    branch = _walk_branch(start, end)
-
-    if not branch:
-        vim.command('unsilent echo "No path to that node from here!"')
-        return
-
-    for node in branch:
-        _undo_to(node.n)
-        vim.command('GundoRenderGraph')
-        normal('zz')
-        _goto_window_for_buffer(back)
-        vim.command('redraw')
-        vim.command('sleep 60m')
-
-GundoPlayTo()
-ENDPYTHON
+    call s:python("GundoPlayTo()")
 endfunction"}}}
 
 "}}}
@@ -953,3 +396,4 @@ command! -nargs=0 GundoRenderGraph call s:GundoRenderGraph()
 autocmd BufNewFile __Gundo__ call s:GundoSettingsGraph()
 autocmd BufNewFile __Gundo_Preview__ call s:GundoSettingsPreview()
 "}}}
+" vim:se fdm=marker:sw=4:


### PR DESCRIPTION
Hi, I've made gundo able to run under Python 3 as I prefer this version of Python.

As Vim has different commands for Python 2 and 3, I have to split the
Python code to a file. Besides the split, I did not change much of the code.

And, Vim's support for Python 3 is currently broken. A [patch](https://groups.google.com/group/vim_dev/browse_thread/thread/bf31218ef41cde6d/f628c170ced04c84) is needed for gundo to run under Python 3.
