### PR TITLE
Add option to close gundo on revert.

### DIFF
--- a/plugin/gundo.vim
+++ b/plugin/gundo.vim
@@ -66,6 +66,9 @@ endif"}}}
 if !exists("g:gundo_map_move_newer")"{{{
     let g:gundo_map_move_newer = 'k'
 endif"}}}
+if !exists("g:gundo_close_on_revert")"{{{
+    let g:gundo_close_on_revert = 1
+endif"}}}
 
 "}}}
 
@@ -883,6 +886,9 @@ def GundoRevert():
 
     vim.command('GundoRenderGraph')
     _goto_window_for_buffer(back)
+
+    if int(vim.eval('g:gundo_close_on_revert')):
+        vim.command('GundoToggle')
 
 GundoRevert()
 ENDPYTHON


### PR DESCRIPTION
I find myself always toggling gundo after a revert.

I imagine this is the most common behaviour for most people. So, I made gundo close after a revert optional based on 'g:gundo_close_on_revert'.
