### PR TITLE
Fix window positions

### DIFF
--- a/plugin/gundo.vim
+++ b/plugin/gundo.vim
@@ -598,11 +598,19 @@ function! s:GundoClose()"{{{
 endfunction"}}}
 
 function! s:GundoOpen()"{{{
+    " Save `splitbelow` value and set it to default to avoid problems with
+    " positioning new windows.
+    let saved_splitbelow = &splitbelow
+    let &splitbelow = 0
+
     call s:GundoOpenPreview()
     exe bufwinnr(g:gundo_target_n) . "wincmd w"
 
     call s:GundoRenderGraph()
     call s:GundoRenderPreview()
+
+    " Restore `splitbelow` value.
+    let &splitbelow = saved_splitbelow
 endfunction"}}}
 
 function! s:GundoToggle()"{{{


### PR DESCRIPTION
Graph and diff windows are swapped if user set `splitbelow` to 1:

```
:set splitbelow    :set nosplitbelow

   +---+---+           +---+---+
   | D |   |           | G |   |
   +---+ S |           +---+ S |
   | G |   |           | D |   |
   +---+---+           +---+---+

 D - diff,  G - graph,  S - source
```

This patch fixes this -- now diff is displayed below graph regardless of `splitbelow` setting.
