### PR TITLE
GundoPlayTo return statement breaks in python 2.4

### DIFF
--- a/autoload/gundo.py
+++ b/autoload/gundo.py
@@ -553,7 +553,10 @@ def GundoPlayTo():
             return None
         nodes.append(current)
 
-        return reversed(nodes) if rev else nodes
+        if rev:
+            return reversed(nodes)
+        else:
+            return nodes
 
     branch = _walk_branch(start, end)
 


### PR DESCRIPTION
Simple change to expand python 2.5+ short syntax of return ... if ... else ...
