### PR TITLE
Fix bug with python3 support crashing Gundo

### DIFF
--- a/autoload/gundo.vim
+++ b/autoload/gundo.vim
@@ -47,12 +47,11 @@ if !exists("g:gundo_prefer_python3")"{{{
     let g:gundo_prefer_python3 = 0
 endif"}}}
 
-if has('python')"{{{
-    let s:has_supported_python = 1
-elseif g:gundo_prefer_python3 && has('python3')
+let s:has_supported_python = 0
+if g:gundo_prefer_python3 && has('python3')"{{{
     let s:has_supported_python = 2
-else
-    let s:has_supported_python = 0
+elseif has('python')"
+    let s:has_supported_python = 1
 endif
 
 if !s:has_supported_python


### PR DESCRIPTION
The recent change that introduced python3 support also made it the default python version used for Gundo. This caused a problem with certain versions of vim where upon toggling the Gundo window, we would be greeted with an error message: `"This Vim cannot execute :py3 after using :python"`

This adds a `g:gundo_prefer_python3` variable (default 0) that can be used to set a preference for python3. By default, python2 will be used.

This also required moving the variable initialization code to the top, since just evaluating `has('python3')` seems to trigger the vim error.
