### PR TITLE
Manually hide and open the Gundo window

### DIFF
--- a/autoload/gundo.vim
+++ b/autoload/gundo.vim
@@ -310,6 +310,14 @@ function! s:GundoToggle()"{{{
     endif
 endfunction"}}}
 
+function! s:GundoShow()"{{{
+	call s:GundoOpen()
+endfunction"}}}
+
+function! s:GundoHide()"{{{
+	call s:GundoClose()
+endfunction"}}}
+
 "}}}
 
 "{{{ Gundo mouse handling

--- a/plugin/gundo.vim
+++ b/plugin/gundo.vim
@@ -18,5 +18,7 @@ let loaded_gundo = 1"}}}
 
 "{{{ Misc
 command! -nargs=0 GundoToggle call gundo#GundoToggle()
+command! -nargs=0 GundoShow call gundo#GundoShow()
+command! -nargs=0 GundoHide call gundo#GundoHide()
 command! -nargs=0 GundoRenderGraph call gundo#GundoRenderGraph()
 "}}}


### PR DESCRIPTION
I was having issues with Gundo and NERDTree getting along when toggling them back and forth. I noticed that NERDTree has the ability to not only toggle the window, but specifically open and close it also. So I went ahead and added these functions to Gundo so that I can do this in my vimrc:

``` vim
" Show NERDTree and hide Gundo if it's open...
nm <leader>nt :GundoHide<cr>:NERDTreeToggle<cr>
" ...and vice versa
nm <leader>gu :NERDTreeClose<cr>:GundoShow<cr>
```
