### PR TITLE
Remove :GundoRenderGraph ?

### DIFF
--- a/plugin/gundo.vim
+++ b/plugin/gundo.vim
@@ -18,5 +18,4 @@ let loaded_gundo = 1"}}}
 
 "{{{ Misc
 command! -nargs=0 GundoToggle call gundo#GundoToggle()
-command! -nargs=0 GundoRenderGraph call gundo#GundoRenderGraph()
 "}}}


### PR DESCRIPTION
Hi,

I don't have a mapping for :GundoToggle and use :Gu<TAB> instead. The first match after TAB is :GundoRenderGraph so I have to press TAB once more to get to :GundoToggle. So I started to wonder what this :GundoRenderGraph is for? It's not mentioned in the documentation, and if I run :GundoRenderGraph before :GundoToggle I get error messages and nothing more.

So if you agree, I have a one-line patch that removes :GundoRenderGraph from the user interface.

By the way, thanks for a _brilliant_ plugin! :-)

Best regards,
Bjørn Forsman
