### PR TITLE
Added option to set the delay used by the playback function

### DIFF
--- a/autoload/gundo.py
+++ b/autoload/gundo.py
@@ -524,6 +524,7 @@ def GundoPlayTo():
 
     target_n = int(vim.eval('s:GundoGetTargetState()'))
     back = int(vim.eval('g:gundo_target_n'))
+    delay = int(vim.eval('g:gundo_playback_delay'))
 
     vim.command('echo "%s"' % back)
 
@@ -570,7 +571,7 @@ def GundoPlayTo():
         normal('zz')
         _goto_window_for_buffer(back)
         vim.command('redraw')
-        vim.command('sleep 60m')
+        vim.command('sleep %dm' % delay)
 
 def initPythonModule():
     if sys.version_info[:2] < (2, 4):

--- a/autoload/gundo.vim
+++ b/autoload/gundo.vim
@@ -49,6 +49,9 @@ endif"}}}
 if !exists("g:gundo_auto_preview")"{{{
     let g:gundo_auto_preview = 1
 endif"}}}
+if !exists("g:gundo_playback_delay")"{{{
+    let g:gundo_playback_delay = 60
+endif"}}}
 
 let s:has_supported_python = 0
 if g:gundo_prefer_python3 && has('python3')"{{{

--- a/doc/gundo.txt
+++ b/doc/gundo.txt
@@ -20,6 +20,7 @@ CONTENTS                                                      *Gundo-contents*
         3.9  gundo_preview_statusline .. |gundo_preview_statusline|
              gundo_tree_statusline ..... |gundo_tree_statusline|
         3.10 gundo_auto_preview ........ |gundo_auto_preview|
+        3.11 gundo_playback_delay ...... |gundo_playback_delay|
     4. License ......................... |GundoLicense|
     5. Bugs ............................ |GundoBugs|
     6. Contributing .................... |GundoContributing|
@@ -215,6 +216,15 @@ through the undo tree (you can still render a specific diff with r).  This can
 be useful on large files and undo trees to speed up Gundo.
 
 Default: 1 (automatically preview diffs)
+
+------------------------------------------------------------------------------
+3.11 g:gundo_playback_delay                             *gundo_playback_delay*
+
+This is the delay in milliseconds between each change when running 'play to'
+mode. Set this to a higher number for a slower playback or to a lower number
+for a faster playback.
+
+Default: 60
 
 ==============================================================================
 4. License                                                      *GundoLicense*


### PR DESCRIPTION
Allow for the option for setting the delay (in milliseconds) to be used
by the GundoPlayTo function in calling vim's sleep command during play
back.
