### PR TITLE
Option to keep the gundo bar focused after restoring.

### DIFF
--- a/autoload/gundo.py
+++ b/autoload/gundo.py
@@ -515,7 +515,8 @@ def GundoRevert():
     _undo_to(target_n)
 
     vim.command('GundoRenderGraph')
-    _goto_window_for_buffer(back)
+    if int(vim.eval('g:gundo_focus_main_buffer')):
+        _goto_window_for_buffer(back)
 
     if int(vim.eval('g:gundo_close_on_revert')):
         vim.command('GundoToggle')

--- a/autoload/gundo.vim
+++ b/autoload/gundo.vim
@@ -52,6 +52,9 @@ endif"}}}
 if !exists("g:gundo_playback_delay")"{{{
     let g:gundo_playback_delay = 60
 endif"}}}
+if !exists("g:gundo_focus_main_buffer")"{{{
+    let g:gundo_focus_main_buffer = 1
+endif"}}}
 
 let s:has_supported_python = 0
 if g:gundo_prefer_python3 && has('python3')"{{{


### PR DESCRIPTION
I find it feels a lot more natural to keep the gundo bar focused after you apply a commit.
I've left it as the default not to but added an option if others want this too.