### PR TITLE
Fix Gundo for paths with spaces

### DIFF
--- a/autoload/gundo.vim
+++ b/autoload/gundo.vim
@@ -280,10 +280,10 @@ endfunction"}}}
 function! s:GundoOpen()"{{{
     if !exists('g:gundo_py_loaded')
         if s:has_supported_python == 2 && g:gundo_prefer_python3
-            exe 'py3file ' . s:plugin_path . '/gundo.py'
+            exe 'py3file ' . escape(s:plugin_path, ' ') . '/gundo.py'
             python3 initPythonModule()
         else
-            exe 'pyfile ' . s:plugin_path . '/gundo.py'
+            exe 'pyfile ' . escape(s:plugin_path, ' ') . '/gundo.py'
             python initPythonModule()
         endif
 


### PR DESCRIPTION
Gundo currently crashes when the plugin is placed on a path that contains spaces due to a failed pyfile command.

The pyfile documentation claims that `The whole argument is used as a single file name.`, but unfortunately this is not the case.  Passing in a path that contains spaces results in `E172: Only one file name allowed`.   We can easily fix this by escaping the directory.