### PR TITLE
Neovim support: line buffers shouldn't contain newlines

### DIFF
--- a/autoload/gundo.py
+++ b/autoload/gundo.py
@@ -336,7 +336,7 @@ def _fmt_time(t):
 def _output_preview_text(lines):
     _goto_window_for_buffer_name('__Gundo_Preview__')
     vim.command('setlocal modifiable')
-    vim.current.buffer[:] = lines
+    vim.current.buffer[:] = [line.rstrip('\n') for line in lines]
     vim.command('setlocal nomodifiable')
 
 def _generate_preview_diff(current, node_before, node_after):


### PR DESCRIPTION
The result of `difflib.unified_diff()` may contains newlines at the end of its
each line. It's suppressed in original Vim, but it's illegal in Neovim.

Since there is no good way to prevent `difflib` from appending newlines to the
results, `_output_preview_text()` function should sanitize it.

###### Reference
- [215th line of src/nvim/api/buffer.c in neovim (a5edc5f2)](https://github.com/neovim/neovim/blob/a5edc5f2572d6d63f7f7a32ae6ec7bcabe1472b6/src/nvim/api/buffer.c#L215)