### PR TITLE
Fix TypeError when using Python 3

### DIFF
--- a/autoload/gundo.py
+++ b/autoload/gundo.py
@@ -378,7 +378,7 @@ def _generate_preview_diff(current, node_before, node_after):
     _undo_to(current)
 
     return list(difflib.unified_diff(before_lines, after_lines,
-                                     before_name, after_name,
+                                     str(before_name), str(after_name),
                                      before_time, after_time))
 
 def _generate_change_preview_diff(current, node_before, node_after):
@@ -398,7 +398,7 @@ def _generate_change_preview_diff(current, node_before, node_after):
     _undo_to(current)
 
     return list(difflib.unified_diff(before_lines, after_lines,
-                                     before_name, after_name,
+                                     str(before_name), str(after_name),
                                      before_time, after_time))
 
 def GundoRenderGraph():


### PR DESCRIPTION
The error shows up on :Gundo and looks like this:

    Error detected while processing function gundo#GundoShow[1]..<SNR>116_GundoShow[4]..<SNR>116_GundoOpen[31]..<SNR>116_GundoRenderPreview:
    line    2:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/mg/.vim/bundle/Gundo/autoload/gundo.py", line 474, in GundoRenderPreview
        _output_preview_text(_generate_preview_diff(current, node_before, node_after))
      File "/home/mg/.vim/bundle/Gundo/autoload/gundo.py", line 382, in _generate_preview_diff
        before_time, after_time))
      File "/usr/lib/python3.5/difflib.py", line 1177, in unified_diff
        _check_types(a, b, fromfile, tofile, fromfiledate, tofiledate, lineterm)
      File "/usr/lib/python3.5/difflib.py", line 1312, in _check_types
        raise TypeError('all arguments must be str, not: %r' % (arg,))
    TypeError: all arguments must be str, not: 46