### PR TITLE
Do not hesitate to use Py3 if it's the only option

### DIFF
--- a/autoload/gundo.vim
+++ b/autoload/gundo.vim
@@ -282,7 +282,7 @@ endfunction"}}}
 
 function! s:GundoOpen()"{{{
     if !exists('g:gundo_py_loaded')
-        if s:has_supported_python == 2 && g:gundo_prefer_python3
+        if s:has_supported_python == 2
             exe 'py3file ' . escape(s:plugin_path, ' ') . '/gundo.py'
             python3 initPythonModule()
         else
@@ -403,7 +403,7 @@ endfunction"}}}
 "{{{ Gundo rendering
 
 function! s:GundoRenderGraph()"{{{
-    if s:has_supported_python == 2 && g:gundo_prefer_python3
+    if s:has_supported_python == 2
         python3 GundoRenderGraph()
     else
         python GundoRenderGraph()
@@ -411,7 +411,7 @@ function! s:GundoRenderGraph()"{{{
 endfunction"}}}
 
 function! s:GundoRenderPreview()"{{{
-    if s:has_supported_python == 2 && g:gundo_prefer_python3
+    if s:has_supported_python == 2
         python3 GundoRenderPreview()
     else
         python GundoRenderPreview()
@@ -419,7 +419,7 @@ function! s:GundoRenderPreview()"{{{
 endfunction"}}}
 
 function! s:GundoRenderChangePreview()"{{{
-    if s:has_supported_python == 2 && g:gundo_prefer_python3
+    if s:has_supported_python == 2
         python3 GundoRenderChangePreview()
     else
         python GundoRenderChangePreview()
@@ -431,7 +431,7 @@ endfunction"}}}
 "{{{ Gundo undo/redo
 
 function! s:GundoRevert()"{{{
-    if s:has_supported_python == 2 && g:gundo_prefer_python3
+    if s:has_supported_python == 2
         python3 GundoRevert()
     else
         python GundoRevert()
@@ -439,7 +439,7 @@ function! s:GundoRevert()"{{{
 endfunction"}}}
 
 function! s:GundoPlayTo()"{{{
-    if s:has_supported_python == 2 && g:gundo_prefer_python3
+    if s:has_supported_python == 2
         python3 GundoPlayTo()
     else
         python GundoPlayTo()

--- a/autoload/gundo.vim
+++ b/autoload/gundo.vim
@@ -61,6 +61,8 @@ if g:gundo_prefer_python3 && has('python3')"{{{
     let s:has_supported_python = 2
 elseif has('python')"
     let s:has_supported_python = 1
+elseif has('python3')"
+    let s:has_supported_python = 2
 endif
 
 if !s:has_supported_python


### PR DESCRIPTION
If Vim is built with Python3 only support there's no sense to ask users to define `g:gundo_prefer_python3` as it's the only option. So let's fallback to `python3` if `python2` runtime is not available.

It's specially crucial for macOS users, since Vim on macOS doesn't support `python2` and `python3` at the same time.