### PR TITLE
Modify default Python version

### DIFF
--- a/autoload/gundo.vim
+++ b/autoload/gundo.vim
@@ -44,7 +44,7 @@ if !exists("g:gundo_close_on_revert")"{{{
     let g:gundo_close_on_revert = 0
 endif"}}}
 if !exists("g:gundo_prefer_python3")"{{{
-    let g:gundo_prefer_python3 = 0
+    let g:gundo_prefer_python3 = 1
 endif"}}}
 if !exists("g:gundo_auto_preview")"{{{
     let g:gundo_auto_preview = 1

--- a/doc/gundo.txt
+++ b/doc/gundo.txt
@@ -240,7 +240,7 @@ Default: 1
 
 Set this to 1 to have Gundo use Python 3 instead of 2 when available.
 
-Default: 0
+Default: 1
 
 ==============================================================================
 4. License                                                      *GundoLicense*


### PR DESCRIPTION
Python 2.x had been abolished in 2020. Therefore, I think the default value of `g:gundo_prefer_python3` option should  change 1 from 0.